### PR TITLE
Rename Identity.Nick to Identity.Name

### DIFF
--- a/client.go
+++ b/client.go
@@ -129,7 +129,7 @@ func (c *Client) ReadEvent() (*Event, error) {
 			c.Logger.Info("!!! Lag:", delta)
 		}
 	} else if e.Command == "NICK" {
-		if e.Identity.Nick == c.currentNick && len(e.Args) > 0 {
+		if e.Identity.Name == c.currentNick && len(e.Args) > 0 {
 			c.currentNick = e.Args[0]
 		}
 	} else if e.Command == "001" {
@@ -153,7 +153,7 @@ func (c *Client) Reply(e *Event, format string, v ...interface{}) error {
 		v = prepend(e.Args[0], v)
 		c.Writef("PRIVMSG %s :"+format, v...)
 	} else {
-		v = prepend(e.Identity.Nick, v)
+		v = prepend(e.Identity.Name, v)
 		c.Writef("PRIVMSG %s :"+format, v...)
 	}
 
@@ -170,7 +170,7 @@ func (c *Client) MentionReply(e *Event, format string, v ...interface{}) error {
 
 	if e.FromChannel() {
 		format = "%s: " + format
-		v = prepend(e.Identity.Nick, v)
+		v = prepend(e.Identity.Name, v)
 	}
 
 	return c.Reply(e, format, v...)
@@ -183,7 +183,7 @@ func (c *Client) CTCPReply(e *Event, format string, v ...interface{}) error {
 		return errors.New("Invalid IRC event")
 	}
 
-	v = prepend(e.Identity.Nick, v)
+	v = prepend(e.Identity.Name, v)
 	c.Writef("NOTICE %s :\x01"+format+"\x01", v...)
 	return nil
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -11,7 +11,7 @@ var eventTests = []struct {
 	Args        []string
 
 	// Identity parsing
-	Nick, User, Host string
+	Name, User, Host string
 
 	// Total output
 	Expect string
@@ -31,7 +31,7 @@ var eventTests = []struct {
 		Prefix: "server.kevlar.net",
 		Cmd:    "PING",
 
-		Host: "server.kevlar.net",
+		Name: "server.kevlar.net",
 
 		Expect: ":server.kevlar.net PING\n",
 	},
@@ -40,7 +40,7 @@ var eventTests = []struct {
 		Cmd:    "NOTICE",
 		Args:   []string{"user", "*** This is a test"},
 
-		Host: "server.kevlar.net",
+		Name: "server.kevlar.net",
 
 		Expect: ":server.kevlar.net NOTICE user :*** This is a test\n",
 	},
@@ -49,7 +49,7 @@ var eventTests = []struct {
 		Cmd:    "PRIVMSG",
 		Args:   []string{"#somewhere", "*** This is a test"},
 
-		Nick: "belakA",
+		Name: "belakA",
 		User: "belakB",
 		Host: "a.host.com",
 
@@ -61,7 +61,7 @@ var eventTests = []struct {
 		Cmd:    "005",
 		Args:   []string{"starkbot", "CHANLIMIT=#:120", "MORE", "are supported by this server"},
 
-		Host: "freenode",
+		Name: "freenode",
 
 		Expect: ":freenode 005 starkbot CHANLIMIT=#:120 MORE :are supported by this server\n",
 	},
@@ -70,7 +70,7 @@ var eventTests = []struct {
 		Cmd:    "PRIVMSG",
 		Args:   []string{"&somewhere", "*** This is a test"},
 
-		Nick: "belakA",
+		Name: "belakA",
 		User: "belakB",
 		Host: "a.host.com",
 
@@ -82,7 +82,7 @@ var eventTests = []struct {
 		Cmd:    "PRIVMSG",
 		Args:   []string{"belak", "*** This is a test"},
 
-		Nick: "belakA",
+		Name: "belakA",
 		User: "belakB",
 		Host: "a.host.com",
 
@@ -93,7 +93,7 @@ var eventTests = []struct {
 		Cmd:    "B",
 		Args:   []string{"C"},
 
-		Host: "A",
+		Name: "A",
 
 		Expect: ":A B C\n",
 	},
@@ -102,7 +102,7 @@ var eventTests = []struct {
 		Cmd:    "C",
 		Args:   []string{"D"},
 
-		User: "A",
+		Name: "A",
 		Host: "B",
 
 		Expect: ":A@B C D\n",
@@ -117,7 +117,7 @@ var eventTests = []struct {
 		Cmd:    "B",
 		Args:   []string{"C", "D"},
 
-		Host: "A",
+		Name: "A",
 
 		Expect: ":A B C D\n",
 	},
@@ -169,8 +169,8 @@ func TestParseIdentity(t *testing.T) {
 			t.Errorf("%d. Got nil for valid identity", i)
 			continue
 		}
-		if test.Nick != pi.Nick {
-			t.Errorf("%d. nick = %q, want %q", i, pi.Nick, test.Nick)
+		if test.Name != pi.Name {
+			t.Errorf("%d. name = %q, want %q", i, pi.Name, test.Name)
 		}
 		if test.User != pi.User {
 			t.Errorf("%d. user = %q, want %q", i, pi.User, test.User)
@@ -232,7 +232,7 @@ func TestEventCopy(t *testing.T) {
 		}
 
 		if c.Identity != nil {
-			c.Identity.Nick += "junk"
+			c.Identity.Name += "junk"
 			if reflect.DeepEqual(e, c) {
 				t.Errorf("%d. copyidentity matched when it shouldn't", i)
 			}

--- a/parser_test.go
+++ b/parser_test.go
@@ -24,6 +24,10 @@ var eventTests = []struct {
 		IsNil: true,
 	},
 	{
+		Expect: ":asd  :",
+		IsNil:  true,
+	},
+	{
 		Expect: ":A",
 		IsNil:  true,
 	},


### PR DESCRIPTION
After looking at other IRC libs and the spec, it looks like I've been parsing identity wrong.

```
prefix     =  servername / ( nickname [ [ "!" user ] "@" host ] )
```

I also changed the name from Nick to Name because it can represent either a servername or a nick.