### PR TITLE
Switch to gometalinter for linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,14 @@ before_install:
   - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
-  - go get github.com/golang/lint/golint
+  # Test deps
+  - go get github.com/stretchr/testify
+  # Linting deps
+  - go get github.com/alecthomas/gometalinter
+  - gometalinter --install
 
 script:
-  - go vet -x ./...
-  - $HOME/gopath/bin/golint ./...
+  - gometalinter --fast ./...
   - go test -v ./...
   - go test -covermode=count -coverprofile=profile.cov
 

--- a/parser.go
+++ b/parser.go
@@ -98,7 +98,7 @@ func ParseMessage(line string) *Message {
 		}
 
 		// Parse the identity, if there was one
-		c.Prefix = ParsePrefix(string(split[0][1:]))
+		c.Prefix = ParsePrefix(split[0][1:])
 		line = split[1]
 	}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -3,6 +3,8 @@ package irc
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var messageTests = []struct {
@@ -34,6 +36,7 @@ var messageTests = []struct {
 	{
 		Prefix: "server.kevlar.net",
 		Cmd:    "PING",
+		Params: []string{},
 
 		Name: "server.kevlar.net",
 
@@ -130,28 +133,18 @@ var messageTests = []struct {
 func TestParseMessage(t *testing.T) {
 	for i, test := range messageTests {
 		m := ParseMessage(test.Expect)
-		if m == nil && !test.IsNil {
-			t.Errorf("%d. Got nil for valid message", i)
-		} else if m != nil && test.IsNil {
-			t.Errorf("%d. Didn't get nil for invalid message", i)
+		if test.IsNil {
+			assert.Nil(t, m, "%d. Didn't get nil for invalid message.", i)
+		} else {
+			assert.NotNil(t, m, "%d. Got nil for valid message.", i)
 		}
 
 		if m == nil {
 			continue
 		}
 
-		if test.Cmd != m.Command {
-			t.Errorf("%d. command = %q, want %q", i, m.Command, test.Cmd)
-		}
-		if len(test.Params) != len(m.Params) {
-			t.Errorf("%d. args = %v, want %v", i, m.Params, test.Params)
-		} else {
-			for j := 0; j < len(test.Params) && j < len(m.Params); j++ {
-				if test.Params[j] != m.Params[j] {
-					t.Errorf("%d. arg[%d] = %q, want %q", i, j, m.Params[j], test.Params[j])
-				}
-			}
-		}
+		assert.Equal(t, test.Cmd, m.Command, "%d. Command doesn't match.", i)
+		assert.EqualValues(t, test.Params, m.Params, "%d. Params don't match.", i)
 	}
 }
 


### PR DESCRIPTION
CC @jsvana

Switched to testify to simplify a number of the assertions. This drops the complexity of the test functions to make the linter happy.