### PR TITLE
Fix CTCP parsing to avoid segfault

### DIFF
--- a/client.go
+++ b/client.go
@@ -29,11 +29,10 @@ var clientFilters = map[string]func(*Client, *Message){
 		// Clean up CTCP stuff so everyone doesn't have to parse it
 		// manually.
 		lastArg := m.Trailing()
-		if len(lastArg) > 0 && lastArg[0] == '\x01' {
-			if i := strings.LastIndex(lastArg, "\x01"); i > -1 {
-				m.Command = "CTCP"
-				m.Params[len(m.Params)-1] = lastArg[1:i]
-			}
+		if len(lastArg) > 1 && lastArg[0] == '\x01' &&
+			lastArg[len(lastArg)-1] == '\x01' {
+			m.Command = "CTCP"
+			m.Params[len(m.Params)-1] = strings.Trim(lastArg, "\x01")
 		}
 	},
 	"NICK": func(c *Client, m *Message) {

--- a/client.go
+++ b/client.go
@@ -2,7 +2,6 @@ package irc
 
 import (
 	"io"
-	"strings"
 )
 
 // clientFilters are pre-processing which happens for certain message
@@ -29,10 +28,10 @@ var clientFilters = map[string]func(*Client, *Message){
 		// Clean up CTCP stuff so everyone doesn't have to parse it
 		// manually.
 		lastArg := m.Trailing()
-		if len(lastArg) > 1 && lastArg[0] == '\x01' &&
-			lastArg[len(lastArg)-1] == '\x01' {
+		lastIdx := len(lastArg) - 1
+		if lastIdx > 0 && lastArg[0] == '\x01' && lastArg[lastIdx] == '\x01' {
 			m.Command = "CTCP"
-			m.Params[len(m.Params)-1] = strings.Trim(lastArg, "\x01")
+			m.Params[len(m.Params)-1] = lastArg[1:lastIdx]
 		}
 	},
 	"NICK": func(c *Client, m *Message) {

--- a/client_test.go
+++ b/client_test.go
@@ -140,4 +140,18 @@ func TestClientHandler(t *testing.T) {
 			Params:  []string{"VERSION"},
 		},
 	}, handler.Messages())
+
+	// CTCP Regression test for PR#47
+	// Proper CTCP should start AND end in \x01
+	rwc.server.WriteString(":world PRIVMSG :\x01VERSION\r\n")
+	err = c.Run()
+	assert.Equal(t, io.EOF, err)
+	assert.EqualValues(t, []*Message{
+		&Message{
+			Tags:    Tags{},
+			Prefix:  &Prefix{Name: "world"},
+			Command: "PRIVMSG",
+			Params:  []string{"\x01VERSION"},
+		},
+	}, handler.Messages())
 }


### PR DESCRIPTION
Previously, a check for the LastIndex was just ensuring that there WAS a \x01 in the message, and not that the Last character in the string was a \x01